### PR TITLE
Change content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ Options -
 swaggerl:load("http://petstore.swagger.io/v2/swagger.json", [{default_headers, [{<<"x-foo">>, <<"foo">>}]}]).
 ```
 
+
+## Extra Options for Swaggerl
+Extra options to configure Swaggerl can be passed through as the 4th argument to `op` and `async_op`. Such as:
+
+```
+swaggerl:op(Spec, Ops, Params, ExtraOptions).
+```
+
+These options include:
+
+- `content_type` (default: `application/json`) - This field is not validated against the API `consumes` spec.
+
 ## Errors
 
 Errors for operations not matching the API specification will be returned from `op` and `async_op` in the form of `{error, Reason, Info}`

--- a/src/swaggerl.erl
+++ b/src/swaggerl.erl
@@ -128,7 +128,8 @@ request_details(Server, Op, OpsMap, InParams) ->
         FullPath, QueryParams),
 
     BodyParam = maps:get(body, SortedParams, []),
-    {Headers, Payload} = encode_body(BodyParam),
+    BodyHeader = <<"application/json">>,
+    {Headers, Payload} = encode_body(BodyParam, BodyHeader, fun jsx:encode/1),
 
     AMethod = method(Method),
     {AMethod, PathWithQueryParams, Headers, Payload}.
@@ -149,12 +150,12 @@ sort_params([H|T], Params, Sorted) ->
                    sort_params(T, Params, NewSorted)
     end.
 
--spec encode_body(list()) -> {list(), binary()}.
-encode_body([]) ->
+-spec encode_body(list(), binary(), fun(() -> binary())) -> {list(), binary()}.
+encode_body([], _ContentTypeHeader, _EncodeFun) ->
     {[], <<>>};
-encode_body([{_Key, Body}]) ->
-    Headers = [{<<"content-type">>, <<"application/json">>}],
-    Payload = jsx:encode(Body),
+encode_body([{_Key, Body}], ContentTypeHeader, EncodeFun) ->
+    Headers = [{<<"content-type">>, ContentTypeHeader}],
+    Payload = EncodeFun(Body),
     {Headers, Payload}.
 
 -spec in_type(binary()) -> atom().

--- a/src/swaggerl.erl
+++ b/src/swaggerl.erl
@@ -48,11 +48,11 @@ op(S=#state{}, Op, Params) when is_list(Op)->
 op(S=#state{}, Op, Params) ->
     op(S, Op, Params, []).
 
-op(S=#state{}, Op, Params, ExtraHTTPOps) when is_list(Op)->
+op(S=#state{}, Op, Params, ExtraOps) when is_list(Op)->
     BOp = binary:list_to_bin(Op),
-    op(S, BOp, Params, ExtraHTTPOps);
+    op(S, BOp, Params, ExtraOps);
 op(#state{ops_map=OpsMap, server=Server, httpoptions=HTTPOptions},
-        Op, Params, ExtraHTTPOps) ->
+        Op, Params, ExtraOps) ->
     RequestDetails = request_details(Server, Op, OpsMap, Params),
     case RequestDetails of
         {error, Reason, Info} -> {error, Reason, Info};
@@ -63,6 +63,7 @@ op(#state{ops_map=OpsMap, server=Server, httpoptions=HTTPOptions},
             RequestHeaders = Headers ++ PayloadHeaders,
             NonSwaggerlHTTPOptions = proplists:delete(default_headers,
                                                       HTTPOptions),
+            ExtraHTTPOps = proplists:get_value(http_options, ExtraOps, []),
             CombinedHTTPOptions = NonSwaggerlHTTPOptions ++ ExtraHTTPOps,
             {ok, _Code, _Headers, ReqRef} = hackney:request(
                 Method, Path, RequestHeaders, Payload, CombinedHTTPOptions),

--- a/src/swaggerl.erl
+++ b/src/swaggerl.erl
@@ -262,6 +262,8 @@ include_op(Op, Operations) ->
 
 method(<<"get">>) ->
     get;
+method(<<"patch">>) ->
+    patch;
 method(<<"post">>) ->
     post.
 


### PR DESCRIPTION
This is needed for Kubernetes operations that have a variety of patch operations with different content types